### PR TITLE
Fix tabs issue causing yaml linting error

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This is a super simple example of how to use Flat Data using the Github GUI.
 	      - name: Setup deno
 	        uses: denoland/setup-deno@main
 	        with:
-          	  deno-version: v1.x
+              deno-version: v1.x
 	      # The third step is a Flat Action step. We fetch the data in the http_url and save it as downloaded_filename
 	      - name: Fetch data 
 	        uses: githubocto/flat@v2


### PR DESCRIPTION
I copied the yaml code for the action directly, and the action failed due to a tab character being used instead of spaces.

- [First action run](https://github.com/vegarsti/flat-demo-bitcoin-price/actions/runs/859611375).
- [Commit which fixed it](https://github.com/vegarsti/flat-demo-bitcoin-price/commit/44d7c31b90e1af2b4d4532ef6f29688a00cd0752).
- [Second action run](https://github.com/vegarsti/flat-demo-bitcoin-price/actions/runs/859629090).

I know that it seems like it's messed up based on the diff in the PR here, but please look at [the rendered README on the branch](https://github.com/vegarsti/flat-demo-bitcoin-price-1/tree/vegarsti-patch-2#part-i-getting-data-into-our-github-repository).